### PR TITLE
Update example with `is`

### DIFF
--- a/python/python/1_Definitions.ipynb
+++ b/python/python/1_Definitions.ipynb
@@ -1126,9 +1126,12 @@
    },
    "outputs": [],
    "source": [
-    "b = 5\n",
-    "c = 5\n",
-    "print(id(b), id(c), id(b) == id(c), b is c)"
+    "b = 257\n",
+    "c = b\n",
+    "d = 257\n",
+    "print('b:', id(b), 'c:', id(c), 'd:', id(d))\n",
+    "print('b is c:', b is c, id(b) == id(c))\n",
+    "print('b is d:', b is d, id(b) == id(d))"
    ]
   },
   {


### PR DESCRIPTION
Stop highlighting integers are the same object since it is only true in the [-5, 256] range...