### PR TITLE
Add more examples to addenadum

### DIFF
--- a/optimization/Addendum.ipynb
+++ b/optimization/Addendum.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "76f6219e",
    "metadata": {
     "slideshow": {
      "slide_type": "slide"
@@ -20,7 +19,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bc9bfe7",
    "metadata": {
     "slideshow": {
      "slide_type": "slide"
@@ -32,13 +30,13 @@
     "* Hybrid approaches: Mix loops for the reciprocal space map and `numpy.sum`\n",
     "  Lowers the memory consumption\n",
     "* Einsum version with `NumPy`\n",
-    "* Multiprocessing with shared memory\n"
+    "* Multiprocessing with shared memory\n",
+    "* Cython version using: $ e^{a+b} = e^{a} e^{b} $\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36b3c390",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,9 +109,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hybrid approaches: Mix loops for the reciprocal space map and `numpy.sum`"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60f1292c",
    "metadata": {
     "slideshow": {
      "slide_type": "slide"
@@ -143,9 +147,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Einsum version with `NumPy`"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bef25d43",
    "metadata": {
     "slideshow": {
      "slide_type": "slide"
@@ -173,7 +183,46 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5be17979",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using Einstein's summation for the circular strained cristal\n",
+    "\n",
+    "def circ_einsum(N, h, k):\n",
+    "    N_2 = N / 2\n",
+    "    x = np.arange(N) - N_2\n",
+    "    y = np.arange(N) - N_2\n",
+    "    o = np.ones(N)\n",
+    "    xa = x.reshape(-1, 1)*o.reshape(1, -1)  # or np.einsum('i,j', x, o)\n",
+    "    ya = o.reshape(-1, 1)*y.reshape(1, -1)  # or np.einsum('i,j', o, y)\n",
+    "    r2 = xa*xa + ya*ya\n",
+    "    mask = r2 <= N_2**2\n",
+    "    r = np.sqrt(r2[mask])\n",
+    "    s = 1. + np.tanh((r - N_2) / w)\n",
+    "    x = xa[mask] * (1. + e0 * s)\n",
+    "    y = ya[mask] * (1. + e0 * s)\n",
+    "    Fhx = np.exp(2j * np.pi * h.reshape(-1, 1)*x.reshape(1, -1))  # or np.einsum('h,x', h, x))\n",
+    "    Fky = np.exp(2j * np.pi * k.reshape(-1, 1)*y.reshape(1, -1))  # or np.einsum('k,y', k, y))\n",
+    "    F = np.einsum('hx,kx->hk', Fhx, Fky)\n",
+    "    return np.abs(F)**2\n",
+    "\n",
+    "%time intensity = circ_einsum(N, h, k)\n",
+    "print(\"Error:\", validate_ci(intensity))\n",
+    "display(intensity)\n",
+    "perf_ci_einsum = %timeit -o circ_einsum(N, h, k)\n",
+    "%memit circ_einsum(N, h, k)  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiprocessing with shared memory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "slide"
@@ -201,20 +250,139 @@
     "    shm.unlink\n",
     "    return result\n",
     "\n",
-    "%time intensity = laue_mp(N, h, k)\n",
+    "%time intensity = laue_mps(N, h, k)\n",
     "print(\"Error:\", validate_sq(intensity))\n",
     "display(intensity)\n",
     "perf_sq_mps = %timeit -o laue_mps(N, h, k)\n",
     "%memit laue_mps(N, h, k)               "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cython"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OMP_NUM_THREADS\"] = str(n_cpu)\n",
+    "# This enables the %cython mode\n",
+    "%load_ext Cython"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%cython --compile-args=-fopenmp --link-args=-fopenmp -a\n",
+    "#cython: embedsignature=True, language_level=3, binding=True\n",
+    "#cython: boundscheck=False, wraparound=False, cdivision=True, initializedcheck=False,\n",
+    "## This is for development:\n",
+    "## cython: profile=True, warn.undeclared=True, warn.unused=True, warn.unused_result=False, warn.unused_arg=True\n",
+    "\n",
+    "import numpy as np\n",
+    "from cython.parallel import prange\n",
+    "from libc.math cimport sqrt, pi, tanh\n",
+    "\n",
+    "# With Cython3: from libc.complex cimport cabs, cexp\n",
+    "# Accessing C code from cython (out of the scope for today)\n",
+    "cdef extern from \"complex.h\" nogil:\n",
+    "    double cabs(double complex)\n",
+    "    double complex cexp(double complex)\n",
+    "\n",
+    "\n",
+    "def laue_cython(int N, \n",
+    "                double[::1] h, \n",
+    "                double[::1] k,\n",
+    "                double w,\n",
+    "                double e0):\n",
+    "    cdef:\n",
+    "        double complex[:, ::1] ehn, ekm\n",
+    "        double[:, ::1] result\n",
+    "        double complex tmp, two_j_pi\n",
+    "        double complex v_h, v_k\n",
+    "        double radius, N_2, strain\n",
+    "        int i_h, i_k, m, n, h_size, k_size\n",
+    "        \n",
+    "    two_j_pi = np.pi*2j\n",
+    "    h_size = h.shape[0]\n",
+    "    k_size = k.shape[0]\n",
+    "    ehn = np.empty((h_size, N), dtype=np.complex128)\n",
+    "    ekm = np.empty((k_size, N), dtype=np.complex128)\n",
+    "    result = np.zeros((h_size, k_size))\n",
+    "    \n",
+    "    with nogil:\n",
+    "        for i_h in range(h_size):\n",
+    "            for n in range(N):\n",
+    "                ehn[i_h, n] = cexp(two_j_pi*h[i_h]*n)\n",
+    "\n",
+    "        for i_k in range(k_size):\n",
+    "            for m in range(N):\n",
+    "                ekm[i_k, m] = cexp(two_j_pi*k[i_k]*m)\n",
+    "\n",
+    "        for i_h in prange(h_size):\n",
+    "            for i_k in range(k_size):\n",
+    "                tmp = 0.0\n",
+    "                for n in range(N):\n",
+    "                    for m in range(N):\n",
+    "                        tmp += ehn[i_h, n] * ekm[i_k, m]\n",
+    "                result[i_h, i_k] += cabs(tmp)**2\n",
+    "\n",
+    "    return np.asarray(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time intensity = laue_cython(N, h, k, w, e0)\n",
+    "print(\"Error:\", validate_sq(intensity))\n",
+    "display(intensity)\n",
+    "perf_sq_cython = %timeit -o laue_cython(N, h, k, w, e0)\n",
+    "%memit laue_cython(N, h, k, w, e0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results\n",
+    "\n",
+    "For square cristal:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"                                    Runtime (ms)  Speed-up (x)\")\n",
+    "ref = perf_sq_hybrid.best\n",
+    "print(f\"Hybrid: for loops+numpy.sum        {1000*perf_sq_hybrid.best:6.1f} ms      {ref/perf_sq_hybrid.best:6.3f}x\")\n",
+    "print(f\"Numpy Einsum                       {1000*perf_sq_einsum.best:6.1f} ms      {ref/perf_sq_einsum.best:6.3f}x\")\n",
+    "print(f\"Multiprocessing with shared memory {1000*perf_sq_mps.best:6.1f} ms      {ref/perf_sq_mps.best:6.3f}x\")\n",
+    "print(f\"Cython with e**(a+b)=e**a+e**b     {1000*perf_sq_cython.best:6.1f} ms      {ref/perf_sq_cython.best:6.3f}x\")"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "Python 3.9 (local venv)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "py39-venv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -226,7 +394,36 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.8.5"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds:
- numpy einsum for circular cristal
- cython e^(a+b)=e^a * e^b for square cristal (x4 speed-up compared to numpy.einsum)

And a sum-up result table at the end