### PR TITLE
Add requirements.txt to software engineering part

### DIFF
--- a/software_engineering/requirements.txt
+++ b/software_engineering/requirements.txt
@@ -1,3 +1,4 @@
+numpy
 rise
 
 # Distribution
@@ -14,4 +15,5 @@ pytest
 myst-parser
 nbsphinx
 sphinx
+sphinx-autobuild
 sphinxcontrib-napoleon


### PR DESCRIPTION
Adding a file with requirements for doing the training.

@mretegan , @loichuder , @payno , @kif add packages if they are missing, I will use this to set-up the computer for the training