### PR TITLE
JL: few adjustments in numpy notebook before April 7, 2025 training.

### DIFF
--- a/python/numpy/Exercise-HPLC.ipynb
+++ b/python/numpy/Exercise-HPLC.ipynb
@@ -144,10 +144,13 @@
     "import matplotlib.colors as colors\n",
     "\n",
     "fig = plt.figure()\n",
-    "plt.imshow(intensities, norm=colors.LogNorm(), aspect=\"auto\")\n",
-    "\n",
+    "#plt.imshow(intensities, norm=colors.LogNorm(), aspect=\"auto\")\n",
     "# Note: with latest version of matplotlib:\n",
-    "# plt.imshow(intensities, norm=\"log\", aspect=\"auto\")"
+    "plt.imshow(intensities, norm=\"log\", aspect=\"auto\")\n",
+    "plt.colorbar()\n",
+    "plt.xlabel('q index')\n",
+    "plt.ylabel('Curve index')\n",
+    "plt.title('Each row of that 2d array (image) is a 1d curve')\n"
    ]
   },
   {
@@ -157,10 +160,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Plot one curve\n",
+    "# Plot the curves 0 and 310\n",
     "fig = plt.figure()\n",
-    "plt.plot(q, intensities[0])\n",
-    "plt.yscale(\"log\")  # Use logarithmic scale for y axis"
+    "plt.plot(q, intensities[0],label=f\"Curve #0 (first row of the intensities array) - no sample\")\n",
+    "plt.plot(q, intensities[310],label=f\"Curve #310 (311th row of the intensities array) - with sample\")\n",
+    "plt.yscale(\"log\")  # Use logarithmic scale for y axis\n",
+    "plt.xlabel(\"q\")\n",
+    "plt.ylabel(\"Intensity\")\n",
+    "plt.title(\"Intensity vs q\")\n",
+    "plt.legend()"
    ]
   },
   {

--- a/python/numpy/exercicesolution.py
+++ b/python/numpy/exercicesolution.py
@@ -47,6 +47,18 @@ def ex4_1():
     return data, binned
 
 
+def ex4_2_0():
+    """Generate a 2D array of [1..9999] then operate a 2x2 binning with loops.
+    """
+    data = numpy.arange(10000).reshape(100, 100)
+    data = data + 1
+    binned = numpy.zeros((50,50))
+    for i in range(50):
+        for j in range(50):
+            binned[i,j] = data[2*i,2*j] + data[2*i + 1,2*j] + data[2*i,2*j + 1] + data[2*i + 1,2*j + 1]
+    return binned
+    
+    
 def ex4_2():
     """Generate a 2D array of [1..9999] then operate a 2x2 binning
     """

--- a/python/numpy/introduction_to_numpy.ipynb
+++ b/python/numpy/introduction_to_numpy.ipynb
@@ -641,9 +641,9 @@
    "source": [
     "https://numpy.org/doc/stable/reference/arrays.scalars.html#sized-aliases\n",
     "\n",
-    "* Integers: ``np.int32``, ``np.int64`` (python ``int``), ``np.uint8`` ...\n",
-    "* Real numbers: ``np.float32``, ``np.float64`` (python ``float``) ...\n",
-    "* Complex: ``np.complex64``, ``np.complex128`` (python ``complex``)"
+    "* Integers: ``np.int32``, ``np.int64``, ``np.uint8`` ...\n",
+    "* Real numbers: ``np.float32``, ``np.float64`` ...\n",
+    "* Complex: ``np.complex64``, ``np.complex128``"
    ]
   },
   {

--- a/python/numpy/introduction_to_numpy.ipynb
+++ b/python/numpy/introduction_to_numpy.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -27,7 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -43,7 +41,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -56,7 +53,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -184,7 +180,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -203,7 +198,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "skip": false,
      "slide_type": ""
@@ -222,7 +216,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -236,7 +229,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "skip"
     },
@@ -254,7 +246,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "skip"
     },
@@ -268,7 +259,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -290,7 +280,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -304,7 +293,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -321,7 +309,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -338,7 +325,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -352,7 +338,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -367,7 +352,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -382,7 +366,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -397,7 +380,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -412,7 +394,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -427,7 +408,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -442,7 +422,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -456,7 +435,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -470,7 +448,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -487,7 +464,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -503,7 +479,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -520,7 +495,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -535,7 +509,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -551,7 +524,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -567,7 +539,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -584,7 +555,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -600,7 +570,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -621,7 +590,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -635,7 +603,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [],
    "source": [
     "np.arange(3, dtype=np.float64)"
@@ -645,7 +617,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -662,7 +633,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -671,16 +641,15 @@
    "source": [
     "https://numpy.org/doc/stable/reference/arrays.scalars.html#sized-aliases\n",
     "\n",
-    "* Integers: ``int32``, ``int64``, ``uint8`` ...\n",
-    "* Real numbers: ``float32``, ``float64`` ...\n",
-    "* Complex: ``complex64``, ``complex128``"
+    "* Integers: ``np.int32``, ``np.int64`` (python ``int``), ``np.uint8`` ...\n",
+    "* Real numbers: ``np.float32``, ``np.float64`` (python ``float``) ...\n",
+    "* Complex: ``np.complex64``, ``np.complex128`` (python ``complex``)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -696,7 +665,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -710,15 +678,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "source": [
-    "Note the two important attributes `a.size` (total number of elements in the array) and `a.itemsize` (size of each element in bytes)."
+    "Note the two important array attributes:\n",
+    "- `a.size`: total number of elements in the array.\n",
+    "- `a.itemsize`: size of each element in bytes.\n",
+    "More on this later."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "skip"
     },
@@ -734,7 +708,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "skip"
     },
@@ -750,7 +723,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "skip"
     },
@@ -765,7 +737,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -780,7 +751,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -796,7 +766,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -812,7 +781,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -827,7 +795,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -843,7 +810,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -858,7 +824,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -872,7 +837,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -892,7 +856,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -911,7 +874,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -931,7 +893,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -948,7 +909,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -963,7 +923,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -976,7 +935,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -992,14 +950,15 @@
     "* Sums: ``sum``, ``cumsum``, ...\n",
     "* Math: ``cos``, ``sin``, ``log10``, ``interp``, ... (https://docs.scipy.org/doc/numpy/reference/routines.math.html)\n",
     "* Indexing, logic functions, sorting\n",
-    "* See: https://docs.scipy.org/doc/numpy/reference/routines.html"
+    "* See: https://docs.scipy.org/doc/numpy/reference/routines.html\n",
+    "\n",
+    "Beware that all these functions are part of `numpy` and must be called with the prefix `np.`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1015,7 +974,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1032,7 +990,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1048,7 +1005,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -1061,10 +1017,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "Suppose you have an array that stacks 10 spectra of 8 energy bins."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1072,7 +1038,7 @@
    },
    "outputs": [],
    "source": [
-    "a = np.array([[0, 1, 2, 3], [4, 5, 6, 7]])\n",
+    "a = np.stack([k*np.ones(8) for k in range(1,11)],axis=1) #Don't focus on the syntax...\n",
     "a"
    ]
   },
@@ -1080,7 +1046,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1088,14 +1053,14 @@
    },
    "outputs": [],
    "source": [
-    "np.min(a)"
+    "# You can compute the mean f the whole array...\n",
+    "np.mean(a)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1103,13 +1068,27 @@
    },
    "outputs": [],
    "source": [
-    "np.min(a, axis=1)"
+    "# ... or the mean of each spectrum\n",
+    "np.mean(a, axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# or the mean of each energy bin:\n",
+    "np.mean(a,axis=1)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -1125,7 +1104,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1141,7 +1119,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1157,7 +1134,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1173,7 +1149,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -1187,7 +1162,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1203,7 +1177,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1218,7 +1191,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1231,7 +1203,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "### Exercise\n",
     "\n",
@@ -1240,7 +1216,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "### A focus on copying arrays (WARNING: slippery!)"
    ]
@@ -1248,7 +1228,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [],
    "source": [
     "# You can create an array by \"copying\" another one\n",
@@ -1261,10 +1245,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [],
    "source": [
-    "#What if you change a?\n",
+    "#What if you change something in a?\n",
     "a[0, 0] = 100\n",
     "print(f\"a=\\n{a}\")\n",
     "print(f\"b=\\n{b}\")"
@@ -1272,7 +1260,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "- When creating an array with `b=a`, `b` is only a VIEW on the elements of `a`.\n",
+    "- Any change on `a` will impact `b`\n",
+    "\n",
+    "=> Solution: use `b=a.copy()` instead."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "source": [
     "- When creating an array with `b=a`, `b` is only a VIEW on the elements of `a`.\n",
     "- Any change on `a` will impact `b`\n",
@@ -1284,7 +1290,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1292,10 +1297,11 @@
    },
    "outputs": [],
    "source": [
+    "a = np.array([[0, 1], [2, 3]])\n",
     "b = a.copy()\n",
     "c = np.copy(a)\n",
     "d = np.array(a, copy=True)\n",
-    "a[0,0] = 0\n",
+    "a [0,0] = 100\n",
     "print(f\"a=\\n{a}\")\n",
     "print(f\"b=\\n{b}\")\n",
     "print(f\"c=\\n{c}\")\n",
@@ -1304,14 +1310,22 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "#### Copy vs view"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "source": [
     "You saw previously data copy. But you can work on the same raw data with different views (representations).\n",
     "\n",
@@ -1324,7 +1338,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "outputs": [],
    "source": [
     "a = np.array([[0, 1], [2, 3]])\n",
@@ -1334,7 +1352,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "source": [
     "![a view](img/a_view.png)\n",
     "![b view](img/b_view.png)"
@@ -1343,7 +1365,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "outputs": [],
    "source": [
     "c = a[0]\n",
@@ -1352,7 +1378,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "source": [
     "![c view](img/c_view.png)"
    ]
@@ -1360,7 +1390,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "outputs": [],
    "source": [
     "d = a.copy()"
@@ -1368,7 +1402,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "source": [
     "![d copy](img/d_copy.png)"
    ]
@@ -1376,7 +1414,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "outputs": [],
    "source": [
     "a[0, 0] = 4"
@@ -1385,7 +1427,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "outputs": [],
    "source": [
     "print(\"a:\", a)\n",
@@ -1397,9 +1443,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
-     "slide_type": "subslide"
+     "slide_type": "slide"
     },
     "tags": []
    },
@@ -1411,9 +1456,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
-     "slide_type": "fragment"
+     "slide_type": "subslide"
     },
     "tags": []
    },
@@ -1429,9 +1473,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
-     "slide_type": "subslide"
+     "slide_type": "slide"
     },
     "tags": []
    },
@@ -1442,9 +1485,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
-     "slide_type": "-"
+     "slide_type": "fragment"
     },
     "tags": []
    },
@@ -1456,7 +1498,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1472,7 +1513,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1486,7 +1526,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -1500,7 +1539,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1516,7 +1554,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1533,7 +1570,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1550,7 +1586,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -1572,7 +1607,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1587,7 +1621,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -1598,7 +1631,7 @@
     "\n",
     "Select elements as with any other Python sequence.\n",
     "\n",
-    "* Indexing starts at `0` for each array dimension\n",
+    "* Indexing starts at `0` for each array dimension®\n",
     "* Indexes can be negative: `x[-1]` is the same as `x[len(x) - 1]`"
    ]
   },
@@ -1606,7 +1639,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1623,7 +1655,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1639,7 +1670,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1654,7 +1684,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1669,7 +1698,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1684,7 +1712,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1699,7 +1726,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1713,7 +1739,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -1727,7 +1752,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1743,7 +1767,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1759,7 +1782,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1776,7 +1798,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1793,7 +1814,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -1807,7 +1827,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1822,7 +1841,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1837,7 +1855,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -1852,7 +1869,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -1869,7 +1885,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1887,7 +1902,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -1902,9 +1916,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "subslide"
     },
     "tags": []
    },
@@ -1919,9 +1932,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "subslide"
     },
     "tags": []
    },
@@ -1933,7 +1945,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -1957,6 +1968,7 @@
     "      1 & 2 & 3 & 4 & \\cdots\\\\\n",
     "      \\end{bmatrix}\n",
     "      $\n",
+    "      (100 values)\n",
     "\n",
     "\n",
     "      binned data:\n",
@@ -1965,14 +1977,15 @@
     "      1 + 2 & 3 + 4 & \\cdots\\\\\n",
     "      \\end{bmatrix}\n",
     "      $\n",
+    "      (50 values)\n",
     "\n",
     "\n",
     "2. Binning with a 2D array 2x2 binning\n",
     "\n",
     "   * 2.1: Generate a 100x100 **2D** array with increasing integers\n",
-    "   * 2.2: Perform a binning such that:\n",
+    "   * 2.2: Perform a 2x2 binning:\n",
     "\n",
-    "      raw data should look like \n",
+    "      Raw data should look like \n",
     "      $\n",
     "      \\begin{bmatrix}\n",
     "      1 & 2 & 3 & 4 & \\cdots\\\\\n",
@@ -1982,9 +1995,10 @@
     "      \\vdots& \\vdots& \\vdots& \\vdots & \\ddots\\\\\n",
     "      \\end{bmatrix}\n",
     "      $\n",
+    "      (size 100 x 100)\n",
     "\n",
     "\n",
-    "      binned data should  look like\n",
+    "      Binned data should look like\n",
     "      $\n",
     "      \\begin{bmatrix}\n",
     "      1 + 2 + 5 + 6 &  3+4+7+8 & \\cdots\\\\\\\\\n",
@@ -1992,6 +2006,7 @@
     "      \\vdots& \\vdots& \\ddots\\\\\n",
     "      \\end{bmatrix}\n",
     "      $\n",
+    "      (size: 50 x 50)\n",
     "\n",
     "\n",
     "3. Set all elements of the resulting array that are below 1000 to 0."
@@ -2001,9 +2016,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "fragment"
     },
     "tags": []
    },
@@ -2016,9 +2030,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "subslide"
     },
     "tags": []
    },
@@ -2034,7 +2047,7 @@
    "execution_count": null,
    "metadata": {
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "subslide"
     }
    },
    "outputs": [],
@@ -2047,7 +2060,7 @@
    "execution_count": null,
    "metadata": {
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "subslide"
     }
    },
    "outputs": [],
@@ -2057,7 +2070,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "source": [
     "### Explanations part 1\n",
     "\n",
@@ -2090,7 +2107,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
    "source": [
     "### Explanations part 2\n",
     "\n",
@@ -2125,7 +2146,44 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Take home message: avoid loops!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%timeit exercicesolution.ex4_2_0()    # Double loop over the new array.\n",
+    "%timeit exercicesolution.ex4_2()      # Using slicing\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "Doing loops on array is **100 times slower** than smart use of slicing.\n",
+    "\n",
+    "=> Take home message: **avoid loops!**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "slideshow": {
      "slide_type": "slide"
     },
@@ -2140,7 +2198,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -2159,7 +2216,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -2182,7 +2238,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -2195,7 +2250,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "-"
     },
@@ -2237,7 +2291,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -2281,7 +2334,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -2297,7 +2349,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -2312,7 +2363,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -2332,7 +2382,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -2349,7 +2398,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -2364,7 +2412,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -2487,7 +2534,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -2511,7 +2557,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -2535,7 +2580,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -2563,7 +2607,7 @@
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "pythontraining",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/python/numpy/introduction_to_numpy.ipynb
+++ b/python/numpy/introduction_to_numpy.ipynb
@@ -1631,7 +1631,7 @@
     "\n",
     "Select elements as with any other Python sequence.\n",
     "\n",
-    "* Indexing starts at `0` for each array dimension®\n",
+    "* Indexing starts at `0` for each array dimension\n",
     "* Indexes can be negative: `x[-1]` is the same as `x[len(x) - 1]`"
    ]
   },

--- a/python/numpy/introduction_to_numpy.ipynb
+++ b/python/numpy/introduction_to_numpy.ipynb
@@ -205,12 +205,13 @@
    "metadata": {
     "editable": true,
     "slideshow": {
+     "skip": false,
      "slide_type": ""
     },
     "tags": []
    },
    "source": [
-    "## installation\n",
+    "## Installation\n",
     "\n",
     "```bash\n",
     "pip install numpy\n",
@@ -237,7 +238,7 @@
    "metadata": {
     "editable": true,
     "slideshow": {
-     "slide_type": "subslide"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -255,7 +256,7 @@
    "metadata": {
     "editable": true,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -709,10 +710,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the two important attributes `a.size` (total number of elements in the array) and `a.itemsize` (size of each element in bytes)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "editable": true,
     "slideshow": {
-     "slide_type": "subslide"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -728,7 +736,7 @@
    "metadata": {
     "editable": true,
     "slideshow": {
-     "slide_type": "fragment"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -744,7 +752,7 @@
    "metadata": {
     "editable": true,
     "slideshow": {
-     "slide_type": "fragment"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -892,8 +900,8 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "# %matplotlib widget (for interactive plots, but requires the ipympl package)\n",
+    "# %matplotlib inline\n",
+    "%matplotlib widget\n",
     "# %matplotlib nbagg\n",
     "\n",
     "from matplotlib import pyplot as plt"
@@ -932,7 +940,7 @@
    "outputs": [],
    "source": [
     "image = np.random.rand(100, 50)\n",
-    "\n",
+    "plt.figure()\n",
     "plt.imshow(image)\n",
     "plt.colorbar()"
    ]
@@ -1222,6 +1230,57 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Continue the [HPLC exercise notebook - Part II](Exercise-HPLC.ipynb#Part-II)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A focus on copying arrays (WARNING: slippery!)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# You can create an array by \"copying\" another one\n",
+    "a = np.array([[0, 1], [2, 3]])\n",
+    "b = a\n",
+    "print(f\"a=\\n{a}\") \n",
+    "print(f\"b=\\n{b}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#What if you change a?\n",
+    "a[0, 0] = 100\n",
+    "print(f\"a=\\n{a}\")\n",
+    "print(f\"b=\\n{b}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- When creating an array with `b=a`, `b` is only a VIEW on the elements of `a`.\n",
+    "- Any change on `a` will impact `b`\n",
+    "\n",
+    "=> Solution: use `b=a.copy()` instead."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -1235,7 +1294,104 @@
    "source": [
     "b = a.copy()\n",
     "c = np.copy(a)\n",
-    "d = np.array(a, copy=True)"
+    "d = np.array(a, copy=True)\n",
+    "a[0,0] = 0\n",
+    "print(f\"a=\\n{a}\")\n",
+    "print(f\"b=\\n{b}\")\n",
+    "print(f\"c=\\n{c}\")\n",
+    "print(f\"d=\\n{d}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Copy vs view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You saw previously data copy. But you can work on the same raw data with different views (representations).\n",
+    "\n",
+    "* copy: duplicate the data\n",
+    "* view: new array object pointing to the same data\n",
+    "\n",
+    "![a in memory](img/array_in_memory.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = np.array([[0, 1], [2, 3]])\n",
+    "b = a.transpose()\n",
+    "a, b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![a view](img/a_view.png)\n",
+    "![b view](img/b_view.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = a[0]\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![c view](img/c_view.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d = a.copy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![d copy](img/d_copy.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a[0, 0] = 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"a:\", a)\n",
+    "print(\"b:\", b)\n",
+    "print(\"c:\", c)\n",
+    "print(\"d:\", d)"
    ]
   },
   {
@@ -1248,7 +1404,7 @@
     "tags": []
    },
    "source": [
-    "Be careful when using copy as it is shallow, and it will not copy object elements within arrays. For this, you need to use `copy.deepcopy`."
+    "Be careful when using `numpy.copy` as it is shallow, and it will not copy object elements within arrays. For these corner cases, you need to use `copy.deepcopy`."
    ]
   },
   {
@@ -1388,7 +1544,7 @@
     "# or define using 'reshape'\n",
     "b = a.reshape((1, 1, 4))\n",
     "print(a.shape)\n",
-    "print(b.shape)"
+    "print(b.shape)\n"
    ]
   },
   {
@@ -1405,7 +1561,7 @@
     "\n",
     "* ``ndim``: Number of dimensions\n",
     "* ``size``: Total number of elements\n",
-    "* ``itemsize``: Size of a single item\n",
+    "* ``itemsize``: Size of a single item (in bytes))\n",
     "* ``strides``: Bytes to step in each dimension\n",
     "* ``flags``: Contiguity of the data in the buffer\n",
     "* ``nbytes``: Size in bytes occupied in memory\n",
@@ -1425,22 +1581,7 @@
    "outputs": [],
    "source": [
     "a = np.array([[1, 2], [3, 4]])\n",
-    "a.ndim"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": "slide"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Exercise\n",
-    "\n",
-    "Continue the [HPLC exercise notebook - Part II](Exercise-HPLC.ipynb#Part-II)"
+    "print(a.ndim,a.dtype,a.size,a.itemsize,a.nbytes)"
    ]
   },
   {
@@ -1799,166 +1940,59 @@
     "tags": []
    },
    "source": [
-    "## Copy vs view\n",
-    "\n",
-    "You saw previously data copy. But you can work on the same raw data with different views (representations).\n",
-    "\n",
-    "* copy: duplicate the data\n",
-    "* view: new array object pointing to the same data\n",
-    "\n",
-    "![a in memory](img/array_in_memory.png)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": "subslide"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "a = np.array([[0, 1], [2, 3]])\n",
-    "b = a.transpose()\n",
-    "a, b"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "source": [
-    "![a view](img/a_view.png)\n",
-    "![b view](img/b_view.png)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": "subslide"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "c = a[0]\n",
-    "c"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": "-"
-    },
-    "tags": []
-   },
-   "source": [
-    "![c view](img/c_view.png)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": "subslide"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "d = a.copy()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "-"
-    }
-   },
-   "source": [
-    "![d copy](img/d_copy.png)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "a[0, 0] = 4"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"a:\", a)\n",
-    "print(\"b:\", b)\n",
-    "print(\"c:\", c)\n",
-    "print(\"d:\", d)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": "slide"
-    },
-    "tags": []
-   },
-   "source": [
     "## Exercise \n",
     "\n",
-    "Perform a 2x2 binning of an image\n",
+    "Suppose we want to shrink the physical size of a 1000x1000 gray-value image by a factor 4, without changing the type of the pixels.\n",
+    "A natural approach is to reduce the number of pixels by a factor 2 in each dimension. This operation is called **binning**. It consists in replacing each 2x2 square in the image by one single pixel value. The next question is: which value should be assigned to each pixel in the new image.\n",
+    "\n",
     "\n",
     "1. Binning with a 1D array\n",
     "      \n",
     "   * 1.1: Generate a **1D** array with 100 elements in increasing order\n",
     "   * 1.2: Perform a binning such that:\n",
     "   \n",
-    "raw data: `1 2 3 4`\n",
+    "      raw data:\n",
+    "      $\n",
+    "      \\begin{bmatrix}\n",
+    "      1 & 2 & 3 & 4 & \\cdots\\\\\n",
+    "      \\end{bmatrix}\n",
+    "      $\n",
     "\n",
-    "binned data: `1+2` `3+4`\n",
+    "\n",
+    "      binned data:\n",
+    "      $\n",
+    "      \\begin{bmatrix}\n",
+    "      1 + 2 & 3 + 4 & \\cdots\\\\\n",
+    "      \\end{bmatrix}\n",
+    "      $\n",
+    "\n",
     "\n",
     "2. Binning with a 2D array 2x2 binning\n",
     "\n",
-    "   * 2.1: Generate a 100x100 **2D** array with elements in increasing order\n",
+    "   * 2.1: Generate a 100x100 **2D** array with increasing integers\n",
     "   * 2.2: Perform a binning such that:\n",
     "\n",
-    "| 1  | 2  | 3  | 4  |\n",
-    "|----|----|----|----|\n",
-    "| 5  | 6  | 7  | 8  |\n",
-    "| 9  | 10 | 11 | 12 |\n",
-    "| 13 | 14 | 15 | 16 |\n",
+    "      raw data should look like \n",
+    "      $\n",
+    "      \\begin{bmatrix}\n",
+    "      1 & 2 & 3 & 4 & \\cdots\\\\\n",
+    "      5 & 6 & 7 & 8& \\cdots\\\\\n",
+    "      9 & 10 & 11 & 12& \\cdots\\\\\n",
+    "      13 & 14 & 15 & 16& \\cdots\\\\\n",
+    "      \\vdots& \\vdots& \\vdots& \\vdots & \\ddots\\\\\n",
+    "      \\end{bmatrix}\n",
+    "      $\n",
     "\n",
-    "| 1+2+5+6    | 3+4+7+8     |\n",
-    "|------------|-------------|\n",
-    "| 9+10+13+14 | 11+12+15+16 |\n",
+    "\n",
+    "      binned data should  look like\n",
+    "      $\n",
+    "      \\begin{bmatrix}\n",
+    "      1 + 2 + 5 + 6 &  3+4+7+8 & \\cdots\\\\\\\\\n",
+    "      9+10+13+14 & 11+12+15+16 & \\cdots\\\\\\\\\n",
+    "      \\vdots& \\vdots& \\ddots\\\\\n",
+    "      \\end{bmatrix}\n",
+    "      $\n",
+    "\n",
     "\n",
     "3. Set all elements of the resulting array that are below 1000 to 0."
    ]
@@ -2035,7 +2069,7 @@
     "\n",
     "```python\n",
     "# You can change the dimension for an other even number to see other examples\n",
-    "dim = 4\n",
+    "dim = 8\n",
     "a = np.arange(dim**2).reshape((dim,dim))\n",
     "a = a+1\n",
     "\n",
@@ -2529,7 +2563,7 @@
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "pythontraining",
    "language": "python",
    "name": "python3"
   },
@@ -2543,7 +2577,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Main changes are:
- [ ] Remove the structured array part.
- [ ] Move all the copy diagrams to where `copy` is adressed in the first place and focus the copy issue on the `np.copy` (but still mention corner cases that require `copy.deepcopy()`.
- [ ] Slightly reword the binning exercise.
- [ ] And many minor changes...
 